### PR TITLE
Fixed to confirm the existence of the attribute "masks"

### DIFF
--- a/pytorch_networks/surface_normals/train.py
+++ b/pytorch_networks/surface_normals/train.py
@@ -225,7 +225,7 @@ db_test_list = []
 if config.train.datasetsTestReal is not None:
     for dataset in config.train.datasetsTestReal:
         if dataset.images:
-            mask_dir = dataset.masks if dataset.masks else ''
+            mask_dir = dataset.masks if hasattr(dataset, 'masks') and dataset.masks else ''
             db = dataloader.SurfaceNormalsDataset(input_dir=dataset.images,
                                                   label_dir=dataset.labels,
                                                   mask_dir=mask_dir,


### PR DESCRIPTION
## Issue

<https://github.com/Shreeyak/cleargrasp/issues/11>

## Description

To prevent AttirbuteError from being raised if the masks attribute is not present in config.yaml, the attribute is checked by the built-in function `hasattr`.